### PR TITLE
wifi: Add provision to create/remove dynamic interface(s).

### DIFF
--- a/wifi/1.4/default/Android.mk
+++ b/wifi/1.4/default/Android.mk
@@ -39,6 +39,9 @@ endif
 ifdef WIFI_AVOID_IFACE_RESET_MAC_CHANGE
 LOCAL_CPPFLAGS += -DWIFI_AVOID_IFACE_RESET_MAC_CHANGE
 endif
+ifdef QC_WIFI_HIDL_FEATURE_DUAL_AP
+LOCAL_CPPFLAGS += -DQC_WIFI_HIDL_FEATURE_DUAL_AP
+endif
 # Allow implicit fallthroughs in wifi_legacy_hal.cpp until they are fixed.
 LOCAL_CFLAGS += -Wno-error=implicit-fallthrough
 LOCAL_SRC_FILES := \

--- a/wifi/1.4/default/wifi_chip.cpp
+++ b/wifi/1.4/default/wifi_chip.cpp
@@ -21,6 +21,7 @@
 #include <cutils/properties.h>
 #include <sys/stat.h>
 #include <sys/sysmacros.h>
+#include <net/if.h>
 
 #include "hidl_return_util.h"
 #include "hidl_struct_util.h"
@@ -664,7 +665,36 @@ Return<void> WifiChip::registerEventCallback_1_4(
                            hidl_status_cb, event_callback);
 }
 
+void WifiChip::QcRemoveAndClearDynamicIfaces() {
+    for (const auto& iface : created_ap_ifaces_) {
+        std::string ifname = iface->getName();
+        legacy_hal::wifi_error legacy_status =
+            legacy_hal_.lock()->deleteVirtualInterface(ifname);
+        if (legacy_status != legacy_hal::WIFI_SUCCESS) {
+            LOG(ERROR) << "Failed to remove interface: " << ifname << " "
+                       << legacyErrorToString(legacy_status);
+        }
+    }
+
+    for (const auto& iface : created_sta_ifaces_) {
+        std::string ifname = iface->getName();
+        legacy_hal::wifi_error legacy_status =
+            legacy_hal_.lock()->deleteVirtualInterface(ifname);
+        if (legacy_status != legacy_hal::WIFI_SUCCESS) {
+            LOG(ERROR) << "Failed to remove interface: " << ifname << " "
+                       << legacyErrorToString(legacy_status);
+        }
+    }
+
+    // created_ap/sta_ifaces are also part of sta/ap_ifaces.
+    // Do no invalidate here.
+
+    created_ap_ifaces_.clear();
+    created_sta_ifaces_.clear();
+}
+
 void WifiChip::invalidateAndRemoveAllIfaces() {
+    QcRemoveAndClearDynamicIfaces();
     invalidateAndClearAll(ap_ifaces_);
     invalidateAndClearAll(nan_ifaces_);
     invalidateAndClearAll(p2p_ifaces_);
@@ -824,18 +854,24 @@ std::pair<WifiStatus, sp<IWifiApIface>> WifiChip::createApIfaceInternal() {
     if (!canCurrentModeSupportIfaceOfTypeWithCurrentIfaces(IfaceType::AP)) {
         return {createWifiStatus(WifiStatusCode::ERROR_NOT_AVAILABLE), {}};
     }
+
+    bool iface_created = false;
     std::string ifname = allocateApIfaceName();
-    legacy_hal::wifi_error legacy_status =
-        legacy_hal_.lock()->createVirtualInterface(
-            ifname,
-            hidl_struct_util::convertHidlIfaceTypeToLegacy(IfaceType::AP));
-    if (legacy_status != legacy_hal::WIFI_SUCCESS) {
-        LOG(ERROR) << "Failed to add interface: " << ifname << " "
-                   << legacyErrorToString(legacy_status);
-        return {createWifiStatusFromLegacyError(legacy_status), {}};
+    if (!if_nametoindex(ifname.c_str())) {
+        legacy_hal::wifi_error legacy_status =
+            legacy_hal_.lock()->createVirtualInterface(
+                ifname,
+                hidl_struct_util::convertHidlIfaceTypeToLegacy(IfaceType::AP));
+        if (legacy_status != legacy_hal::WIFI_SUCCESS) {
+            LOG(ERROR) << "Failed to add interface: " << ifname << " "
+                       << legacyErrorToString(legacy_status);
+            return {createWifiStatusFromLegacyError(legacy_status), {}};
+        }
+        iface_created = true;
     }
     sp<WifiApIface> iface = new WifiApIface(ifname, legacy_hal_, iface_util_);
     ap_ifaces_.push_back(iface);
+    if (iface_created) created_ap_ifaces_.push_back(iface);
     for (const auto& callback : event_cb_handler_.getCallbacks()) {
         if (!callback->onIfaceAdded(IfaceType::AP, ifname).isOk()) {
             LOG(ERROR) << "Failed to invoke onIfaceAdded callback";
@@ -872,11 +908,15 @@ WifiStatus WifiChip::removeApIfaceInternal(const std::string& ifname) {
     // nan/rtt objects over AP iface. But, there is no harm to do it
     // here and not make that assumption all over the place.
     invalidateAndRemoveDependencies(ifname);
-    legacy_hal::wifi_error legacy_status =
-        legacy_hal_.lock()->deleteVirtualInterface(ifname);
-    if (legacy_status != legacy_hal::WIFI_SUCCESS) {
-        LOG(ERROR) << "Failed to remove interface: " << ifname << " "
-                   << legacyErrorToString(legacy_status);
+    if (findUsingName(created_ap_ifaces_, ifname) != nullptr) {
+        iface_util_.lock()->setUpState(ifname, false);
+        legacy_hal::wifi_error legacy_status =
+            legacy_hal_.lock()->deleteVirtualInterface(ifname);
+        if (legacy_status != legacy_hal::WIFI_SUCCESS) {
+            LOG(ERROR) << "Failed to remove interface: " << ifname << " "
+                       << legacyErrorToString(legacy_status);
+        }
+        invalidateAndClear(created_ap_ifaces_, iface);
     }
     invalidateAndClear(ap_ifaces_, iface);
     for (const auto& callback : event_cb_handler_.getCallbacks()) {
@@ -993,18 +1033,23 @@ WifiChip::createStaIfaceInternal() {
     if (!canCurrentModeSupportIfaceOfTypeWithCurrentIfaces(IfaceType::STA)) {
         return {createWifiStatus(WifiStatusCode::ERROR_NOT_AVAILABLE), {}};
     }
+    bool iface_created = false;
     std::string ifname = allocateStaIfaceName();
-    legacy_hal::wifi_error legacy_status =
-        legacy_hal_.lock()->createVirtualInterface(
-            ifname,
-            hidl_struct_util::convertHidlIfaceTypeToLegacy(IfaceType::STA));
-    if (legacy_status != legacy_hal::WIFI_SUCCESS) {
-        LOG(ERROR) << "Failed to add interface: " << ifname << " "
-                   << legacyErrorToString(legacy_status);
-        return {createWifiStatusFromLegacyError(legacy_status), {}};
+    if (!if_nametoindex(ifname.c_str())) {
+        legacy_hal::wifi_error legacy_status =
+            legacy_hal_.lock()->createVirtualInterface(
+                ifname,
+                hidl_struct_util::convertHidlIfaceTypeToLegacy(IfaceType::STA));
+        if (legacy_status != legacy_hal::WIFI_SUCCESS) {
+            LOG(ERROR) << "Failed to add interface: " << ifname << " "
+                       << legacyErrorToString(legacy_status);
+            return {createWifiStatusFromLegacyError(legacy_status), {}};
+        }
+        iface_created = true;
     }
     sp<WifiStaIface> iface = new WifiStaIface(ifname, legacy_hal_, iface_util_);
     sta_ifaces_.push_back(iface);
+    if (iface_created) created_sta_ifaces_.push_back(iface);
     for (const auto& callback : event_cb_handler_.getCallbacks()) {
         if (!callback->onIfaceAdded(IfaceType::STA, ifname).isOk()) {
             LOG(ERROR) << "Failed to invoke onIfaceAdded callback";
@@ -1038,11 +1083,15 @@ WifiStatus WifiChip::removeStaIfaceInternal(const std::string& ifname) {
     }
     // Invalidate & remove any dependent objects first.
     invalidateAndRemoveDependencies(ifname);
-    legacy_hal::wifi_error legacy_status =
-        legacy_hal_.lock()->deleteVirtualInterface(ifname);
-    if (legacy_status != legacy_hal::WIFI_SUCCESS) {
-        LOG(ERROR) << "Failed to remove interface: " << ifname << " "
-                   << legacyErrorToString(legacy_status);
+    if (findUsingName(created_sta_ifaces_, ifname) != nullptr) {
+        iface_util_.lock()->setUpState(ifname, false);
+        legacy_hal::wifi_error legacy_status =
+            legacy_hal_.lock()->deleteVirtualInterface(ifname);
+        if (legacy_status != legacy_hal::WIFI_SUCCESS) {
+            LOG(ERROR) << "Failed to remove interface: " << ifname << " "
+                       << legacyErrorToString(legacy_status);
+        }
+        invalidateAndClear(created_sta_ifaces_, iface);
     }
     invalidateAndClear(sta_ifaces_, iface);
     for (const auto& callback : event_cb_handler_.getCallbacks()) {

--- a/wifi/1.4/default/wifi_chip.h
+++ b/wifi/1.4/default/wifi_chip.h
@@ -259,6 +259,7 @@ class WifiChip : public V1_4::IWifiChip {
     std::string allocateApIfaceName();
     std::string allocateStaIfaceName();
     bool writeRingbufferFilesInternal();
+    void QcRemoveAndClearDynamicIfaces();
 
     ChipId chip_id_;
     std::weak_ptr<legacy_hal::WifiLegacyHal> legacy_hal_;
@@ -281,6 +282,9 @@ class WifiChip : public V1_4::IWifiChip {
     bool debug_ring_buffer_cb_registered_;
     hidl_callback_util::HidlCallbackHandler<IWifiChipEventCallback>
         event_cb_handler_;
+
+    std::vector<sp<WifiApIface>> created_ap_ifaces_;
+    std::vector<sp<WifiStaIface>> created_sta_ifaces_;
 
     DISALLOW_COPY_AND_ASSIGN(WifiChip);
 };

--- a/wifi/1.4/default/wifi_feature_flags.cpp
+++ b/wifi/1.4/default/wifi_feature_flags.cpp
@@ -79,14 +79,28 @@ constexpr ChipModeId kMainModeId = chip_mode_ids::kV3;
 #      define WIFI_HAL_INTERFACE_COMBINATIONS {{{STA}, 1}, {{P2P}, 1}}
 #    endif
 #  else
-#    ifdef WIFI_HIDL_FEATURE_AWARE
-//     (1 STA + 1 AP) or (1 STA + 1 of (P2P or NAN))
-#      define WIFI_HAL_INTERFACE_COMBINATIONS {{{STA}, 1}, {{AP}, 1}},\
-                                              {{{STA}, 1}, {{P2P, NAN}, 1}}
+#    ifdef QC_WIFI_HIDL_FEATURE_DUAL_AP
+#      ifdef WIFI_HIDL_FEATURE_AWARE
+//       (1 STA + 1 AP) or (1 STA + 1 of (P2P or NAN)) or (2 AP)
+#        define WIFI_HAL_INTERFACE_COMBINATIONS {{{STA}, 1}, {{AP}, 1}},\
+                                                {{{STA}, 1}, {{P2P, NAN}, 1}},\
+                                                {{{AP}, 2}}
+#      else
+//       (1 STA + 1 AP) or (1 STA + 1 P2P) or (2 AP)
+#        define WIFI_HAL_INTERFACE_COMBINATIONS {{{STA}, 1}, {{AP}, 1}},\
+                                                {{{STA}, 1}, {{P2P}, 1}},\
+                                                {{{AP}, 2}}
+#      endif
 #    else
-//     (1 STA + 1 AP) or (1 STA + 1 P2P)
-#      define WIFI_HAL_INTERFACE_COMBINATIONS {{{STA}, 1}, {{AP}, 1}},\
-                                              {{{STA}, 1}, {{P2P}, 1}}
+#      ifdef WIFI_HIDL_FEATURE_AWARE
+//       (1 STA + 1 AP) or (1 STA + 1 of (P2P or NAN))
+#        define WIFI_HAL_INTERFACE_COMBINATIONS {{{STA}, 1}, {{AP}, 1}},\
+                                                {{{STA}, 1}, {{P2P, NAN}, 1}}
+#      else
+//       (1 STA + 1 AP) or (1 STA + 1 P2P)
+#        define WIFI_HAL_INTERFACE_COMBINATIONS {{{STA}, 1}, {{AP}, 1}},\
+                                                {{{STA}, 1}, {{P2P}, 1}}
+#      endif
 #    endif
 #  endif
 #else


### PR DESCRIPTION
This commit does following:
 - Add/Remove softap interface at runtime, if needed.
 - Use wlan.concurrent.interface as default softap interface.
 - Add build time support to enable SAP+SAP feature using
   QC_WIFI_HIDL_FEATURE_DUAL_AP flag. if enabled use wlan.interface
   as second SAP interface.

Change-Id: Icde3d54eda0f142e20f33cdb7ed95152eeee0bec
CRs-Fixed: 2257197

wifi: Add logic to create secondary interface for STA mode too.

Previously we introduced dynamic interface create/remove logic for
SAP interface where wlan.concurrent.interface was given first
preference for SAP interface.

Remove this preference and fallback to use the default order of
choosing interface names. Also add create/remove logic for secondary
interface in STA mode too.

Change-Id: Iec5c4492096327a18e67f5129736a9bd3c8533f0
CRs-Fixed: 2268421

wifi: Remove dynamic interfaces as part of wifi chip stop/cleanup.

During interface initialization for additional SAP/STA request, new
interface is created dynamically. This interface is removed during
teardown. In cases, where wifi stop request comes before teardown,
dynamically created interface(s) are not getting destroyed.

This CL is to remove dynamically created interfaces as part of wifi
chip stop/cleanup. Additionally, move invalidateAndRemoveDependencies
before remove interface.

Change-Id: I2df499252670f63ee22223176c71273b33f70679
CRs-Fixed: 2533958

[Pig]: Update to LA.QSSI.11.0.r1-06700-qssi.0

Change-Id: I9d469526965e595d77732913f6607dcafab19a01